### PR TITLE
Change bootstrap to use dep, update README to reflect this

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ go:
   - "1.8.x"
   - "master"
 before_install:
-  - sudo add-apt-repository ppa:masterminds/glide -y && sudo apt-get update -y
-  - sudo apt-get install -y glide
+  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 install: make bootstrap
 script: make test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: mflowd
 
 bootstrap:
-	glide install
+	dep ensure -v
 
 mflowd:
 	go build

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the results into a Google Pub/Sub topic. The metrics flow daemon polls a subscri
 
 ## Build it from scratch
 
-1. Make sure you have `glide` installed (if you don't know how to install it, follow [this](https://github.com/Masterminds/glide#install) link)
+1. Make sure you have `dep` installed (if you don't know how to install it, follow [this](https://github.com/golang/dep#installation) link)
 2. `make bootstrap`
 3. `make test`
 4. `make mflowd`


### PR DESCRIPTION
You don't seem to actually be using glide anymore so when following the setup instructions the bootstrap step fails (no glide.yaml present in the project).

This PR updates both the make step and the readme to reflect this change.